### PR TITLE
Fixed typos with Weight Page section

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ Some resources possess an emoticon to help you understand which type of content 
 
 ### Best practices
 
-- [ ] **Weight page:** ![High](http://res.cloudinary.com/djnyaloac/image/upload/v1508238836/level-checklist-high.png) The weight of each page is between 0ko and 500ko
+- [ ] **Weight page:** ![High](http://res.cloudinary.com/djnyaloac/image/upload/v1508238836/level-checklist-high.png) The weight of each page is between 0kb and 500kb
 
-> * 🛠 [Website Page Size Online Checker](https://smallseotools.com/website-page-size-checker/)
+> * 🛠 [Website Page Analysis](https://tools.pingdom.com)
 > * 📖 [Size Limit: Make the Web lighter](https://evilmartians.com/chronicles/size-limit-make-the-web-lighter)
 
 - [ ] **Minified:** ![Medium](http://res.cloudinary.com/djnyaloac/image/upload/v1508238836/level-checklist-medium.png) Your HTML is minified


### PR DESCRIPTION
Great checklist! Also changed the Page Weight tool to a more user friendly and less ad covered tool.
Also wondering in the Font Sections it mentions ```2 MO``` is this meant to be ```2 MB``` or something else? A quick google search gave me nothing about MO so a little explanation would be great!