### PR TITLE
Fix link from Table of Contents to Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is based on Front-End developers' years of experience, with the additions com
 6. **[Images](#images)**
 7. **[JavaScript](#javascript)**
 8. **[Security](#security)**
-9. **[Performance](#performance)**
+9. **[Performance](#performance-1)**
 10. **[Accessibility](#accessibility)**
 11. **[SEO](#seo)**
 


### PR DESCRIPTION
Hello,

Small fix, the link from the Table of Contents to Performance section actually leads to CSS' performance section. This commit fixes this.