### PR TITLE
Add prefetching techniques in performance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,36 @@ Some resources possess an emoticon to help you understand which type of content 
 > * 📖 [Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
 > * 🛠 [Browser Cookie Limits](http://browsercookielimits.squawky.net/)
 
+### Preparing upcoming requests
+
+> 📖 [Explanation of the following techniques](https://css-tricks.com/prefetching-preloading-prebrowsing/)
+
+* [ ] **DNS resolution:** ![Low][low_img] DNS of third-party services that may be needed are resolved in advance during idle time using `dns-prefetch`.
+
+```html
+<link rel="dns-prefetch" href="https://example.com">
+```
+
+* [ ] **Preconnection:** ![Low][low_img] DNS lookup, TCP handshake and TLS negociation with services that will be needed soon is done in advance during idle time using `preconnect`.
+
+```html
+<link rel="preconnect" href="https://example.com">
+```
+
+* [ ] **Prefetching:** ![Low][low_img] Resources that will be needed soon (e.g. lazy loaded images) are requested in advance during idle time using `prefetch`.
+
+```html
+<link rel="prefetch" href="image.png">
+```
+
+* [ ] **Preloading:** ![Low][low_img] Resources needed in the current page (e.g. scripts placed at the end of `<body>`) in advance using `preload`.
+
+```html
+<link rel="preload" href="app.js">
+```
+
+> 📖 [Difference between prefetch and preload](https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf)
+
 ### Performance testing
 
 * [ ] **Google PageSpeed:** ![High][high_img] All your pages were tested (not only the homepage) and have min 90/100.


### PR DESCRIPTION
Hello,

I've created [this checklist](https://github.com/antarestupin/performance-checklist) focused on performance recently and I'd like to share some practices that I don't see yet in this list.

I wanted to begin with techniques allowing to prepare upcoming requests during browser's idle time, so I'm adapting [this section](https://github.com/antarestupin/performance-checklist#prepare-next-requests) to the format used here.

I've created a sub-section in `Performance`, but I'm not sure of where this section should be placed as there are performance related practices spread over all the list, so it's open to discussion. Same for the levels of flexibility.