### PR TITLE
updated SEO info about Ttile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Some resources possess an emoticon to help you understand which type of content 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ```
 
-* [ ] **Title:** ![High][high_img] A title is used on all pages (SEO: No more than 65 characters, website title included).
+* [ ] **Title:** ![High][high_img] A title is used on all pages (SEO: Google calculate the pixel width of the characters used in the title, cut off between 472 and 482 pixels. Average character limit would be around 55-characters).
 
 ```html
 <!-- Document Title -->


### PR DESCRIPTION
Meta title in Google search result has pixel width limits and not character count limits.