### PR TITLE
Added color header for Chrome on Android devices

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Join the chat at https://gitter.im/Front-End-Checklist/Lobby](https://badges.gitter.im/Front-End-Checklist/Lobby.svg)](https://gitter.im/Front-End-Checklist/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Front‑End_Checklist followed](https://img.shields.io/badge/Front‑End_Checklist-followed-brightgreen.svg)](https://github.com/thedaviddias/Front-End-Checklist/)
 [![Contributors](https://img.shields.io/github/contributors/thedaviddias/Front-End-Checklist.svg)](https://github.com/thedaviddias/Front-End-Checklist/graphs/contributors)
+[![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/thedaviddias/front-end-checklist)
 [![CC0](https://img.shields.io/badge/license-CC0-green.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 The **Front-End Checklist** is an exhaustive list of all elements you need to have / to test before launching your site / page HTML to production.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Some resources possess an emoticon to help you understand which type of content 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ```
 
+* [ ] **Chrome Theme Color:** ![Low][low_img] C
+
+```html
+<!-- Theme color for Chrome in android devices -->
+<meta name="theme-color" content="#99CC00"/>
+```
+
 * [ ] **Title:** ![High][high_img] A title is used on all pages (SEO: Google calculate the pixel width of the characters used in the title, cut off between 472 and 482 pixels. Average character limit would be around 55-characters).
 
 ```html

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Some resources possess an emoticon to help you understand which type of content 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 ```
 
-* [ ] **Chrome Theme Color:** ![Low][low_img] C
+* [ ] **Chrome Theme Color:** ![Low][low_img] Chrome theme color for android devices is present
 
 ```html
-<!-- Theme color for Chrome in android devices -->
+<!-- Theme color for Chrome on Android devices -->
 <meta name="theme-color" content="#99CC00"/>
 ```
 


### PR DESCRIPTION
With this line of html is possible to set a custom color on Chrome's searchbar header only for Android devices
![photo_2017-10-25_21-06-13](https://user-images.githubusercontent.com/7620920/32018049-ed919250-b9c8-11e7-9710-74147437c9a2.png)
