### PR TITLE
improve to display atts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 
 ### HTML tags
 
-* [ ] **Language attribute:** ![High][high_img] The ``lang`` attribute of your website is specified and related to the language of the current page.
+* [ ] **Language attribute:** ![High][high_img] The `lang` attribute of your website is specified and related to the language of the current page.
 
 ```html
 <html lang="en">
@@ -365,7 +365,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 
 * [ ] **Retina:** ![Low][low_img] You provide layout images x2 or 3x, support retina display.
 * [ ] **Sprite:** ![Medium][medium_img] Small images are in a sprite file (in the case of icons, they can be in an SVG sprite image).
-* [ ] **Width and Height:** ![High][high_img] Set ``width`` and ``height`` attributes on `<img>` if the final rendered image size is known (can be omitted for CSS sizing).
+* [ ] **Width and Height:** ![High][high_img] Set `width` and `height` attributes on `<img>` if the final rendered image size is known (can be omitted for CSS sizing).
 * [ ] **Alternative text:** ![High][high_img] All `<img>` have an alternative text which describe the image visually.
 
 > * 📖 [Alt-texts: The Ultimate Guide](https://axesslab.com/alt-texts/)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 
 ### HTML tags
 
-* [ ] **Language attribute:** ![High][high_img] The language attribute of your website is specified and related to the language of the current page.
+* [ ] **Language attribute:** ![High][high_img] The ``lang`` attribute of your website is specified and related to the language of the current page.
 
 ```html
 <html lang="en">
@@ -365,7 +365,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 
 * [ ] **Retina:** ![Low][low_img] You provide layout images x2 or 3x, support retina display.
 * [ ] **Sprite:** ![Medium][medium_img] Small images are in a sprite file (in the case of icons, they can be in an SVG sprite image).
-* [ ] **Width and Height:** ![High][high_img] Set width and height attributes on `<img>` if the final rendered image size is known (can be omitted for CSS sizing).
+* [ ] **Width and Height:** ![High][high_img] Set ``width`` and ``height`` attributes on `<img>` if the final rendered image size is known (can be omitted for CSS sizing).
 * [ ] **Alternative text:** ![High][high_img] All `<img>` have an alternative text which describe the image visually.
 
 > * 📖 [Alt-texts: The Ultimate Guide](https://axesslab.com/alt-texts/)


### PR DESCRIPTION
I confused what width and height are meaning during I was translating this cool documentation.
I think attributes should be written like \`width`.

Thanks 😊 