### PR TITLE
Add "(Not for HTTP/2)" note to spriting images

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Minimum required xml markup for the browserconfig.xml file is as follows:
 > * 📖 [How to Build Responsive Images with srcset](https://www.sitepoint.com/how-to-build-responsive-images-with-srcset/)
 
 * [ ] **Retina:** ![Low][low_img] You provide layout images 2x or 3x, support retina display.
-* [ ] **Sprite:** ![Medium][medium_img] Small images are in a sprite file (in the case of icons, they can be in an SVG sprite image).
+* [ ] **Sprite:** ![Medium][medium_img] Small images are in a sprite file (in the case of icons, they can be in an SVG sprite image). *(Not for HTTP/2)*
 * [ ] **Width and Height:** ![High][high_img] Set `width` and `height` attributes on `<img>` if the final rendered image size is known (can be omitted for CSS sizing).
 * [ ] **Alternative text:** ![High][high_img] All `<img>` have an alternative text which describe the image visually.
 


### PR DESCRIPTION
As far as I'm aware, there is no reason to sprite images other than cutting down on the number of image requests. As this isn't relevant to HTTP/2, a "(Not for HTTP/2)" note (similar to the CSS concatenation note) seems worthwhile.