### PR TITLE
Promote sidebar to its own layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "front-end-checklist",
+  "name": "Front-End-Checklist",
   "version": "0.0.1",
   "description": "The perfect Front-End Checklist for modern websites and meticulous developers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Front-End-Checklist",
+  "name": "front-end-checklist",
   "version": "0.0.1",
   "description": "The perfect Front-End Checklist for modern websites and meticulous developers",
   "scripts": {

--- a/src/styles/components/_c-nav.scss
+++ b/src/styles/components/_c-nav.scss
@@ -74,6 +74,7 @@
         top: 50px;
         flex-direction: column;
         width: auto;
+        will-change: transform;
       }
 
       .c-button {


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

Prevents repainting while scrolling by pomoting the sidebar to its own compositor layer.

#### Proposed changes:

Promotes the sidebar to its own layer by using `will-change: transform`

👍 Thank you!
