### PR TITLE
Package name fix — remove uppercase characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "front-end-checklist",
+  "name": "Front-End-Checklist",
   "version": "0.0.1",
   "description": "The perfect Front-End Checklist for modern websites and meticulous developers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Front-End-Checklist",
+  "name": "front-end-checklist",
   "version": "0.0.1",
   "description": "The perfect Front-End Checklist for modern websites and meticulous developers",
   "scripts": {

--- a/src/styles/components/_c-nav.scss
+++ b/src/styles/components/_c-nav.scss
@@ -74,6 +74,7 @@
         top: 50px;
         flex-direction: column;
         width: auto;
+        will-change: transform;
       }
 
       .c-button {


### PR DESCRIPTION
The package name contains uppercase characters, which aren't allowed in a valid `package.json` file:
```
String does not match the pattern of "^(?:@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$".
```
Changed name to `front-end-checklist`