### PR TITLE
[Simple Adjustment] Removed possibility of duplicating gists in HEAD …

### DIFF
--- a/src/scripts/components/Tools.js
+++ b/src/scripts/components/Tools.js
@@ -142,6 +142,10 @@ class Tools {
       btn.addEventListener(
         'click',
         () => {
+          const btnExpandActived = btn.parentNode.querySelector('.--noevent');
+          if (btnExpandActived) {
+            btnExpandActived.classList.remove('--noevent');
+          }
           new Dropdown().allDropdown({btn});
         }
       );
@@ -152,6 +156,7 @@ class Tools {
       btn.addEventListener(
         'click',
         () => {
+          btn.classList.add('--noevent');
           new Dropdown().allDropdown({btn});
         }
       );

--- a/src/styles/components/_c-button.scss
+++ b/src/styles/components/_c-button.scss
@@ -153,6 +153,7 @@
     &.--noevent {
       pointer-events: none;
       border-color: $secondary;
+
       .icon {
         fill: $secondary;
       }

--- a/src/styles/components/_c-button.scss
+++ b/src/styles/components/_c-button.scss
@@ -149,6 +149,14 @@
         }
       }
     }
+
+    &.--noevent {
+      pointer-events: none;
+      border-color: $secondary;
+      .icon {
+        fill: $secondary;
+      }
+    }
   }
 
   #{$namespace-button}__group {


### PR DESCRIPTION
Hello @thedaviddias,

When I click the expand-all button multiple times in the HEAD block, it ends up adding several github gists. So I made these changes to stop this from happening.

It's my first help with an open-source project, so if I have not followed your pattern, I'm sorry. :(

Congrats about your project!
