### PR TITLE
Comment should not precede DOCTYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Some resources possess an emoticon to help you understand which type of content 
 * [ ] **Doctype:** ![High][high_img] The Doctype is HTML5 and is at the top of all your HTML pages.
 
 ```html
-<!-- Doctype HTML5 -->
-<!doctype html>
+<!doctype html> <!-- HTML5 -->
 ```
 
 > * 📖 [Determining the character encoding - HTML5 W3C](https://www.w3.org/TR/html5/syntax.html#determining-the-character-encoding)


### PR DESCRIPTION




**Fixes**: #188

**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x ] Check the commit's or even all commits' message styles matches our requested structure.
- [x ] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

The purpose of <!doctype html> is to ensure standards compliant rendering, avoiding quirks mode, even in older browsers.  To fulfill this purpose, it must be the first item in the file. 

Older IE browsers will trigger quirks mode instead of standards mode if <!doctype html> is not at the very beginning of the document.

https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode

"Make sure you put the DOCTYPE right at the beginning of your HTML document. Anything before the DOCTYPE, like a comment or an XML declaration will trigger quirks mode in Internet Explorer 9 and older."

#### Proposed changes:

- Moved the comment after the doctype


