### PR TITLE
Solution to issue #202 - file-based persistence.

### DIFF
--- a/src/scripts/components/Storage.js
+++ b/src/scripts/components/Storage.js
@@ -14,15 +14,19 @@ class Storage {
       instance = this;
 
       // TODO: Make sure this is the right position for these event-setters.
-      let loadButton = document.getElementsByClassName('js-load-from-file-button');
-      let loadInput = document.getElementsByClassName('js-load-from-file-input');
+      let loadButton = document.getElementsByClassName(
+        'js-load-from-file-button',
+      );
+      let loadInput = document.getElementsByClassName(
+        'js-load-from-file-input',
+      );
       if (loadButton.length && loadInput.length) {
         loadButton = loadButton[0];
         loadInput = loadInput[0];
-        loadButton.addEventListener('click', function() {
+        loadButton.addEventListener('click', () => {
           loadInput.click();
         });
-        loadButton.addEventListener('change', function(e) {
+        loadButton.addEventListener('change', e => {
           if (e.target.files.length) {
             instance.loadLocalStorageFromFile(e.target.files[0]);
           }
@@ -256,12 +260,12 @@ class Storage {
       window.Blob
     ) {
       let fileReader = new FileReader();
-      fileReader.onload = function(e) {
+      fileReader.onload = e => {
         try {
           let fileData = JSON.parse(e.target.result);
           localStorage.clear();
           let fileDataEntries = Object.entries(fileData);
-          for (let i = 0; i < fileDataEntries.length; i++) {
+          for (let i = 0; i < fileDataEntries.length; i += 1) {
             localStorage.setItem(fileDataEntries[i][0], fileDataEntries[i][1]);
           }
           window.location = window.location;

--- a/src/scripts/components/Storage.js
+++ b/src/scripts/components/Storage.js
@@ -12,36 +12,38 @@ class Storage {
   constructor() {
     if (!instance) {
       instance = this;
-
-      // TODO: Make sure this is the right position for these event-setters.
-      let loadButton = document.getElementsByClassName(
-        'js-load-from-file-button',
-      );
-      let loadInput = document.getElementsByClassName(
-        'js-load-from-file-input',
-      );
-      if (loadButton.length && loadInput.length) {
-        loadButton = loadButton[0];
-        loadInput = loadInput[0];
-        loadButton.addEventListener('click', () => {
-          loadInput.click();
-        });
-        loadButton.addEventListener('change', e => {
-          if (e.target.files.length) {
-            instance.loadLocalStorageFromFile(e.target.files[0]);
-          }
-        });
-      }
-
-      let save = document.getElementsByClassName('js-save-to-file');
-      if (save.length) {
-        save[0].addEventListener('click', instance.saveLocalStorageToFile);
-      }
+      instance.setPersistenceButtonEvents();
     }
 
     this.body = document.querySelectorAll('[data-section-id]');
 
     return instance;
+  }
+
+  setPersistenceButtonEvents() {
+    // TODO: Make sure this is the right position for these event-setters.
+    let loadButton = document.getElementsByClassName(
+      'js-load-from-file-button',
+    );
+    let loadInput = document.getElementsByClassName('js-load-from-file-input');
+
+    if (loadButton.length && loadInput.length) {
+      loadButton = loadButton[0];
+      loadInput = loadInput[0];
+      loadButton.addEventListener('click', () => {
+        loadInput.click();
+      });
+      loadButton.addEventListener('change', e => {
+        if (e.target.files.length) {
+          instance.loadLocalStorageFromFile(e.target.files[0]);
+        }
+      });
+    }
+
+    let save = document.getElementsByClassName('js-save-to-file');
+    if (save.length) {
+      save[0].addEventListener('click', instance.saveLocalStorageToFile);
+    }
   }
 
   checkingOption(list, keyName) {
@@ -250,6 +252,21 @@ class Storage {
 
     document.body.removeChild(element);
   }
+  
+  loadLocalStorageFromString(input) {
+    try {
+      let fileData = JSON.parse(input);
+      localStorage.clear();
+      let fileDataEntries = Object.entries(fileData);
+      for (let i = 0; i < fileDataEntries.length; i += 1) {
+        localStorage.setItem(fileDataEntries[i][0], fileDataEntries[i][1]);
+      }
+      window.location = window.location;
+    } catch (ev) {
+      // TODO: Translate and/or notify better?
+      alert('The file was not valid.');
+    }
+  }
 
   loadLocalStorageFromFile(file) {
     if (
@@ -260,19 +277,9 @@ class Storage {
       window.Blob
     ) {
       let fileReader = new FileReader();
+      let self = this;
       fileReader.onload = e => {
-        try {
-          let fileData = JSON.parse(e.target.result);
-          localStorage.clear();
-          let fileDataEntries = Object.entries(fileData);
-          for (let i = 0; i < fileDataEntries.length; i += 1) {
-            localStorage.setItem(fileDataEntries[i][0], fileDataEntries[i][1]);
-          }
-          window.location = window.location;
-        } catch (ev) {
-          // TODO: Translate and/or notify better?
-          alert('The file was not valid.');
-        }
+        self.loadLocalStorageFromString(e.target.result);
       };
       fileReader.readAsText(file);
     } else {

--- a/src/views/components/c-new-form.pug
+++ b/src/views/components/c-new-form.pug
@@ -20,3 +20,11 @@
   button.button.btn--danger.js-reset-all
     +svg-icon.icon.icon-reset(data-icon-name='reset')
     | #[=translation.form.BUTTON_START_NEW]
+
+  //- TODO: how to translate and where to put this markup?
+  button.button.btn--danger.js-save-to-file
+    | #[=translation.form.BUTTON_SAVE_TO_FILE]
+
+  //- TODO: how to translate and where to put this markup?
+  button.button.btn--danger.js-load-from-file-button
+    | #[input(type='file', name='files', accept='.json', hidden).js-load-from-file-input]

--- a/src/views/components/c-new-form.pug
+++ b/src/views/components/c-new-form.pug
@@ -27,4 +27,5 @@
 
   //- TODO: how to translate and where to put this markup?
   button.button.btn--danger.js-load-from-file-button
+    | #[=translation.form.BUTTON_LOAD_FROM_FILE]
     | #[input(type='file', name='files', accept='.json', hidden).js-load-from-file-input]


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #202 

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
When using the checklist on multiple long-running projects it would be great to have a way to persist the filled in data not only on paper/pdf printout, but in a json file for later access or storing in a repository side by side with the codebase the data refers to.
This introduces the said feature.

__Note:__ This is a first draft, meant to be discussed to see if I move in the right direction. Feel free to give me feedback and tell me where I can improve the code. Especially the 5 included TODOs should be discussed.

#### Proposed changes:

- Add a method to the Storage-class that allows for saving the current localStorage content to a JSON file for out-of-browser-persistance.
- Add a method to the Storage-class that allows to load the files into the localStorage and replace everything in there (using filed from the export above).
- Add 2 buttons to the header section to access these features.

👍 Thank you!


#### Comment:
I didn't find any CONTRIBUTING.md, but I deem my commit messages informative and non-offensive, so I checked the box.
The tests failed on parsing `\src\scripts\main.js`, which I didn't touch. (`Line 3: Unexpected token`) I did not change existing functionality, so I do not expect failing tests.

The linter only complains about:
* unexpected alerts
  * These should be replaced by more pleasant means of feedback. As this is a first draft I have not yet looked into your default feedback mechanisms.