### PR TITLE
fix link to contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ If you have any question or suggestion, don't hesitate to use Gitter or Twitter:
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
+This project exists thanks to all the people who contribute. [[Contribute]](.github/CONTRIBUTING.md).
 <a href="https://github.com/thedaviddias/Front-End-Checklist/graphs/contributors"><img src="https://opencollective.com/front-end-checklist/contributors.svg?width=890" /></a>
 
 


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

The link to CONTRIBUTING.md in the README.md is not correct as the file is in the .github folder.

#### Proposed changes:

- fix the link

👍 Thank you!
