### PR TITLE
Remove leftover reference to X-UA Compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some resources possess an emoticon to help you understand which type of content 
 
 > * 📖 [Determining the character encoding - HTML5 W3C](https://www.w3.org/TR/html5/syntax.html#determining-the-character-encoding)
 
-*The next 3 meta tags (Charset, X-UA Compatible and Viewport) need to come first in the head.*
+*The next 2 meta tags (Charset and Viewport) need to come first in the head.*
 
 * [ ] **Charset:** ![High][high_img] The charset (UTF-8) is declared correctly.
 


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: N/A

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
Changes a small piece of literature in [`README.md`](https://github.com/thedaviddias/Front-End-Checklist/blob/8686dd6d17c14985e1f7619288acd418f3d3eafd/README.md) due to `X-UA-Compatible` being deprecated in IE11, this slipped through 8686dd6.


#### Proposed changes:

- N/A

👍 Thank you!
