### PR TITLE
Corrected Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ The **Front-End Checklist** repository consists of two branches:
 
 #### 1. `master`
 
-This branch consists of the `README.md` file that is automatically reflected on the [Front-End Checklist](http://frontendchecklist.com/) website.
+This branch consists of the `README.md` file that is automatically reflected on the [Front-End Checklist](https://frontendchecklist.io) website.
 
 #### 2. `develop`
 


### PR DESCRIPTION
- The link went to an empty site, now it refers to the actual site. This shouldn't mess with any tests or guidelines, as I only changed the address. Still read the guidelines and I think this is fine.

<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

Possibly outdated link on the README changed for actual link

👍 You're welcome :)