### PR TITLE
Expand if item has videos

### DIFF
--- a/src/views/components/checklist/dropdown.pug
+++ b/src/views/components/checklist/dropdown.pug
@@ -1,6 +1,6 @@
 .c-checklist__column.c-checklist__dropdown
 
   //- Check if the item has content, if not hide the button
-  if item.tools || item.documentation || item.code
+  if item.tools || item.documentation || item.code || item.video
     button.button-icon.js-dropdown.c-checklist__dropdown__button(aria-label="Open the description section")
       +svg-icon.icon.icon-arrow(data-icon-name='arrow')


### PR DESCRIPTION
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
I think we should have had dropdowns if videos available.
They should reveal links to these videos.

I was expecting this:
![image](https://user-images.githubusercontent.com/1020565/60744692-2bc1ca80-9f88-11e9-8d23-9371cf26df71.png)

Instead, on frontendchecklist.io, we see the below with no dropdown:
![image](https://user-images.githubusercontent.com/1020565/60744710-3da36d80-9f88-11e9-96c4-06c9d589b5d7.png)
