### PR TITLE
Fix the link for Dirty Markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Visualize and generate automatically our social meta tags with [Meta Tags](https
 
 * [ ] **HTML Lint:** ![High][high_img] I use tools to help me analyze any issues I could have on my HTML code.
 
-> * 🛠 [Dirty markup](https://dirtymarkup.com/)
+> * 🛠 [Dirty markup](https://www.10bestdesign.com/dirtymarkup/)
 
 > * 🛠 [webhint](https://webhint.io/)
 


### PR DESCRIPTION
**Fixes**: #

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
The link for Dirty Markup pointed to a redirect URL whose cert has been invalid for 3 three months.

#### Proposed changes:

- Change the link to go to the page that we were being redirected to anyway so the invalid cert doesn't stop/confuse people


👍 Thank you!
