### PR TITLE
[gitpod-setup] remove the build task to make the server startup fast + make the description more precise. 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: npm install && npm run build
+  - init: npm install
     command: npm run start
 ports:
   - port: 3000

--- a/README.md
+++ b/README.md
@@ -759,7 +759,13 @@ This branch will be used to make some significant changes to the structure, cont
 
 ### Online Setup with a single Click
 
-You can use gitpod ( A free VS Code like IDE) for contributing online, with a single click it will launch a ready to code workspace with all the dependencies pre-installed, build finished & the web server running so that you can start coding straight away.
+You can use Gitpod ( A free online VS Code-like IDE) for contributing, with a single click it will launch a workspace and automatically:
+
+- clone the frontendchecklist repo.
+- install the dependencies.
+- run `npm run start`.
+
+So that you can start straight away.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/thedaviddias/Front-End-Checklist)
 


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

This PR enhances the Gitpod setup by removing the build task to make the server start fast and it also makes its description precise in the `README.md` 
