### PR TITLE
Lower upper limit of the web fonts payload

### DIFF
--- a/data/en/items/webfonts.json
+++ b/data/en/items/webfonts.json
@@ -26,7 +26,7 @@
   {
     "title": "Webfont size",
     "priority": "High",
-    "description": "Webfont sizes don't exceed 2 MB (all variants included).",
+    "description": "Webfont sizes don't exceed 100 KB (all variants included).",
     "tags": ["all", "webfont"]
   },
   {


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [ X] Check the commit's or even all commits' message styles matches our requested structure.
- [ X] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

Currently in the checklist, the Webfont size check states the total size of the webfonts must not exceed 2 MB. I see two problems with this:
1. this is very much in conflict with the check "Page weight" which communicates an total max page weight of 500 KB
2. Loading 2 MB of fonts onto a page would hurt page speed/performance significantly

#### Proposed changes:

Change the upper limit from 2 MB to 100 KB for webfont size.
100 KB is sufficient to load 2 variants of a font in WOFF (after gzip) or WOFF2 format, after doing subsetting.

👍 Thank you!
