### PR TITLE
Decrease Google Analytics importance to Low

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Visualize and generate automatically our social meta tags with [Meta Tags](https
 
 ## SEO
 
-* [ ] **Google Analytics:** ![High][high_img] Google Analytics is installed and correctly configured.
+* [ ] **Google Analytics:** ![Low][low_img] Google Analytics is installed and correctly configured.
 
 > * 🛠 [Google Analytics](https://analytics.google.com/analytics/web/)
 > * 🛠 [GA Checker (and others)](http://www.gachecker.com/)


### PR DESCRIPTION
As discussed by others in #405, there's no good reason for Google Analytics being in a category where it:
> can't be omitted by any reason.

To add on to what others have said, this statement above is also misleading. There shouldn't be a requirement to fork over user data to Google as part of all, or even most, front end development.

Fixes #405 