### PR TITLE
Remove pagination from SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,18 +692,6 @@ Visualize and generate automatically our social meta tags with [Meta Tags](https
 
 > * 📖 [Sitemap guidelines - Google Support](https://support.google.com/webmasters/answer/183668?hl=en)
 
-* [ ] **Pagination link tags:** ![Medium][medium_img] Provide `rel="prev"` and `rel="next"` to indicate paginated content.
-
-> * 🛠 [Pagination (rel="prev/next") Testing Tool](https://technicalseo.com/seo-tools/rel-prev-next/)
-
-> * 📖 [Pagination guidelines - Google Support](https://support.google.com/webmasters/answer/1663744?hl=en)
-
-```html
-<!-- Example: Pagination link tags for page 2 of a paginated list -->
-<link rel="prev" href="https://example.com/?page=1">
-<link rel="next" href="https://example.com/?page=3">
-```
-
 **[⬆ back to top](#table-of-contents)**
 
 ---


### PR DESCRIPTION
#### Short description of what this resolves:
Remove pagination from SEO section, because it's not an SEO index anymore and google has removed the related docs, see [here](https://twitter.com/googlesearchc/status/1108726443251519489?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1108726443251519489%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Ftechnicalseo.com%2Ftools%2Frel-prev-next%2F).
