### PR TITLE
fix: pin 4 unpinned action(s)

### DIFF
--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -21,14 +21,14 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.0.2
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --config ./lychee.toml --verbose --no-progress README.md
           fail: true
 
       - name: Create Issue From File
         if: env.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         with:
           title: Link Checker Report
           content-filepath: ./lychee-out.md

--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 9
 
@@ -33,7 +33,7 @@ jobs:
         run: pnpm format:check
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2.0.2
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --config ./lychee.toml --verbose --no-progress README.md
           fail: true


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/links-checker.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/readme-check.yml` | Pinned 2 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.