### PR TITLE
adds meta tag theme-color and prefers-color-scheme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ Minimum required xml markup for the `browserconfig.xml` file is as follows:
 - 📖 [Browser configuration schema reference](https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/dn320426(v=vs.85))
 <!-- prettier-ignore-end -->
 
+- [ ] **Theme color & color-scheme:** ![Medium][medium_img] Add a `theme-color` meta tag and support for
+      `prefers-color-scheme` so the browser UI (address bar, task switcher) matches the site theme.
+
+<!-- prettier-ignore-start -->
+```html
+<!-- Default theme color (used by Android and some browsers) -->
+<meta name="theme-color" content="#ffffff">
+
+<!-- Theme color per color scheme (modern browsers support media attribute) -->
+<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+
+<!-- Opt-in for both light and dark color schemes (CSS) -->
+<style>
+      :root { color-scheme: light dark; }
+</style>
+```
+<!-- prettier-ignore-end -->
+
 - [ ] **Canonical:** ![Medium][medium_img] Use `rel="canonical"` to avoid duplicate content.
 
 <!-- prettier-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ Minimum required xml markup for the `browserconfig.xml` file is as follows:
 <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
 
-<!-- Opt-in for both light and dark color schemes (CSS) -->
+<!-- Declare support for both light and dark color schemes -->
+<meta name="color-scheme" content="light dark">
+
+<!-- Complement with CSS so form controls and UA-rendered surfaces match -->
 <style>
       :root { color-scheme: light dark; }
 </style>


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #714 

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
Adds missing support for `<meta name="theme-color">` and `prefers-color-scheme` to the Head section of the checklist, improving coverage of UX standards resolving #714.

#### Proposed changes:
- Added `theme-color` meta tag to the Head checklist items.
- Added guidance for using `prefers-color-scheme` media query in CSS.
- Updated documentation to explain why these are important for accessibility and user experience.

👍 Thank you!
