### PR TITLE
docs: add Agent QA E2E resource

### DIFF
--- a/packages/content/rules/en/testing/e2e-testing.mdx
+++ b/packages/content/rules/en/testing/e2e-testing.mdx
@@ -56,11 +56,16 @@ sources:
     role: implementation
     authority: primary
 resources:
+  - name: Agent QA
+    url: 'https://github.com/vostride/agent-qa'
+    type: tool
   - name: Playwright
     url: 'https://playwright.dev/'
     type: tool
 ---
 End-to-end tests verify that your application works correctly from the user's perspective, testing complete user journeys across multiple components and services.
+
+Teams that want natural-language, black-box user-flow coverage can use [Agent QA](https://github.com/vostride/agent-qa) alongside code-level Playwright or Cypress suites; it complements rather than replaces their framework-level assertions.
 
 ## Code Example
 

--- a/skills/e2e-testing/references/rule.md
+++ b/skills/e2e-testing/references/rule.md
@@ -7,6 +7,8 @@
 ---
 End-to-end tests verify that your application works correctly from the user's perspective, testing complete user journeys across multiple components and services.
 
+Teams that want natural-language, black-box user-flow coverage can use [Agent QA](https://github.com/vostride/agent-qa) alongside code-level Playwright or Cypress suites; it complements rather than replaces their framework-level assertions.
+
 ## Code Example
 
 ```typescript


### PR DESCRIPTION
## Summary

Add Agent QA as a supporting tool in the existing end-to-end testing rule and explain its complementary boundary in the rule body.

## Contributor checklist

- [x] The commit message follows the repository's requested conventional format.
- [x] The content, lint-adjacent validators, tests, and production build pass.

## Why it fits

[Agent QA](https://github.com/vostride/agent-qa) runs natural-language black-box regression suites against web and mobile interfaces and retains scoped test memory between runs. That makes it relevant to this rule's complete-user-journey focus.

The new sentence deliberately keeps Playwright and Cypress as the code-level examples and says Agent QA complements rather than replaces their framework-level assertions. Agent QA is an independent external tool, not a Front-End Checklist integration.

The current FSL-1.1-ALv2 license is source-available rather than OSI open source and converts to Apache-2.0 after two years. I am affiliated with Vostride and Agent QA.

## Validation

- `pnpm score:rules packages/content/rules/en/testing/e2e-testing.mdx` gives the rule an A (98/104, 94%) and passes the quality gate.
- `pnpm validate:rule-structure` checks all 385 rules with zero errors.
- `pnpm validate:sources` checks all 385 rules with zero missing sources or broken URLs, including the new canonical Agent QA resource URL.
- `pnpm generate:skills` regenerates all 385 derived skills successfully; the corresponding generated E2E reference is included in this change.
- The pre-commit hook passes every applicable check.
- The pre-push hook passes the production web build, all 37 test suites, and all 106 tests.
- `git diff --check` passes.
- The content tree, issues, and pull requests contain no existing Agent QA entry or proposal.
